### PR TITLE
Replaced #ifdef LINUX with #ifdef __linux__

### DIFF
--- a/SPI_DeviceSimulator/SPIDeviceSimulator.cpp
+++ b/SPI_DeviceSimulator/SPIDeviceSimulator.cpp
@@ -1,7 +1,7 @@
-// SPITemplate.cpp : Definiert den Einstiegspunkt für die Konsolenanwendung.
+// SPITemplate.cpp : Definiert den Einstiegspunkt fï¿½r die Konsolenanwendung.
 //
 
-#ifdef LINUX
+#ifdef __linux__
 #include <unistd.h>
 #else
 #include "stdafx.h"
@@ -14,7 +14,7 @@
 #include "EthernetServer.h"
 #include "ResourceProvider.h"
 
-#ifdef LINUX
+#ifdef __linux__
 int main()
 {
     if(true)


### PR DESCRIPTION
Fixed linux build issues caused by test `#ifdef LINUX`. The definition `LINUX` is not defined on linux systems. The standard way to test for linux is `#ifdef __linux__`
